### PR TITLE
feat: Convert styles using classnames module instead of ternary strings

### DIFF
--- a/frontend/app/(auth)/input-otp/from-login/page.tsx
+++ b/frontend/app/(auth)/input-otp/from-login/page.tsx
@@ -14,10 +14,7 @@ import OTPInput from "@/components/auth/input/OTPInput";
 import AuthHeader from "@/components/auth/header/Header-auth";
 
 // import images
-import Logomark from "@/public/images/auth/Logomark.svg";
 import SendRequestIcon from "@/public/images/auth/SendRequest.svg";
-import SettingIcon from "@/public/images/auth/ic-settings.svg";
-import OTPVerified from "@/public/images/auth/OTPVerified.svg";
 import BackArrowIcon from "@/public/images/auth/arrow-ios-back-fill.svg";
 
 // import from other modules
@@ -111,7 +108,7 @@ export default function Page() {
                   Resend code
                 </Link>
               </Flex>
-              <Flex justify="center" className={`w-full gap-x-1 ${"hidden"}`}>
+              <Flex justify="center" className="w-full gap-x-1">
                 <Typography className="text-[12px]/[16px] lg:text-[14px]/[22px] font-medium">
                   Already have an account?
                 </Typography>
@@ -122,11 +119,7 @@ export default function Page() {
                   Login
                 </Link>
               </Flex>
-              <Flex
-                justify="center"
-                align="center"
-                className={`w-full gap-x-1`}
-              >
+              <Flex justify="center" align="center" className="w-full gap-x-1">
                 <Link
                   href="/login"
                   className="text-[14px]/[20px] font-semibold flex text-[black]"

--- a/frontend/app/(auth)/input-otp/from-signup/page.tsx
+++ b/frontend/app/(auth)/input-otp/from-signup/page.tsx
@@ -19,6 +19,7 @@ import OTPVerified from "@/public/images/auth/OTPVerified.svg";
 import BackArrowIcon from "@/public/images/auth/arrow-ios-back-fill.svg";
 
 // import from other modules
+import classNames from "classnames";
 
 export default function Page() {
   const router = useRouter();
@@ -72,9 +73,10 @@ export default function Page() {
               priority
               src={!isVerified ? SendRequestIcon : OTPVerified}
               alt="SendRequest"
-              className={`${
+              className={classNames(
+                "lg:w-[188px] h-auto",
                 !isVerified ? "w-[146px]" : "w-[200px]"
-              } lg:w-[188px] h-auto`}
+              )}
             />
             <Flex vertical className="w-full px-4 gap-y-8 lg:gap-y-2">
               <Typography className="text-center text-[20px]/[30px] lg:text-[32px]/[48px] font-bold">
@@ -92,7 +94,7 @@ export default function Page() {
             </Flex>
             <Flex
               justify="center"
-              className={`w-full px-4 ${isVerified ? "hidden" : ""}`}
+              className={classNames("w-full px-4", isVerified ? "hidden" : "")}
             >
               <OTPInput />
             </Flex>
@@ -100,25 +102,28 @@ export default function Page() {
               <Flex vertical className="w-full gap-y-3">
                 <Button
                   onClick={onClickVerifyOTPHandler}
-                  className={`text-[15px]/[26px] font-bold text-[white] bg-main py-[11px] h-fit ${
+                  className={classNames(
+                    "text-[15px]/[26px] font-bold text-[white] bg-main py-[11px] h-fit",
                     isVerified ? "hidden" : ""
-                  }`}
+                  )}
                 >
                   Verify OTP
                 </Button>
                 <Button
                   onClick={onClickContinueHandler}
-                  className={`text-[15px]/[26px] font-bold text-[white] bg-main py-[11px] h-fit ${
+                  className={classNames(
+                    "text-[15px]/[26px] font-bold text-[white] bg-main py-[11px] h-fit",
                     !isVerified ? "hidden" : ""
-                  }`}
+                  )}
                 >
                   Continue
                 </Button>
                 <Button
                   onClick={onClickCancelHandler}
-                  className={`text-[15px]/[26px] font-bold text-secondary bg-[white] py-[11px] h-fit lg:hidden ${
+                  className={classNames(
+                    "text-[15px]/[26px] font-bold text-secondary bg-[white] py-[11px] h-fit lg:hidden",
                     isVerified ? "hidden" : ""
-                  }`}
+                  )}
                 >
                   Cancel
                 </Button>
@@ -126,7 +131,10 @@ export default function Page() {
               <Flex
                 justify="center"
                 align="center"
-                className={`w-full gap-x-1 ${isVerified ? "hidden" : ""}`}
+                className={classNames(
+                  "w-full gap-x-1",
+                  isVerified ? "hidden" : ""
+                )}
               >
                 <Typography className="text-[12px]/[16px] font-medium">
                   Don’t have a code?
@@ -141,7 +149,7 @@ export default function Page() {
               <Flex
                 justify="center"
                 align="center"
-                className={`w-full gap-x-1 hidden`}
+                className="w-full gap-x-1 hidden"
               >
                 <Link
                   href="#"

--- a/frontend/app/(auth)/reset-password/page.tsx
+++ b/frontend/app/(auth)/reset-password/page.tsx
@@ -19,6 +19,9 @@ import OTPVerified from "@/public/images/auth/OTPVerified.svg";
 import BackArrowIcon from "@/public/images/auth/arrow-ios-back-fill.svg";
 import PasswordUpdated from "@/public/images/auth/PasswordUpdated.svg";
 
+// import from other modules
+import classNames from "classnames";
+
 export default function Page() {
   const router = useRouter();
 
@@ -69,11 +72,12 @@ export default function Page() {
                 priority
                 src={!isUpdated ? OTPVerified : PasswordUpdated}
                 alt="OTPVerified"
-                className={`${
+                className={classNames(
+                  "h-auto",
                   !isUpdated
                     ? "w-[200px] lg:w-[188px]"
                     : "w-[132px] lg:w-[86.58px] rounded-full shadow-xl"
-                } h-auto`}
+                )}
               />
               <Flex className="w-full flex flex-col justify-center items-center gap-y-8 lg:gap-y-2 px-4 lg:py-4">
                 <Typography className="text-[20px]/[30px] lg:text-[32px]/[48px] font-bold text-center">
@@ -93,9 +97,10 @@ export default function Page() {
               </Flex>
               <Flex
                 vertical
-                className={`w-full px-4 lg:px-6 gap-y-5 ${
+                className={classNames(
+                  "w-full px-4 lg:px-6 gap-y-5",
                   isUpdated ? "hidden" : ""
-                }`}
+                )}
               >
                 <Flex vertical className="w-full gap-y-2">
                   <Typography className="text-[12px]/[16px] font-semibold">
@@ -112,9 +117,10 @@ export default function Page() {
               </Flex>
               <Flex
                 vertical
-                className={`w-full px-4 lg:px-6 gap-y-6 ${
+                className={classNames(
+                  "w-full px-4 lg:px-6 gap-y-6",
                   isUpdated ? "hidden" : ""
-                }`}
+                )}
               >
                 <Flex vertical className={`w-full gap-y-3`}>
                   <Button
@@ -162,9 +168,10 @@ export default function Page() {
               </Flex>
               <Flex
                 vertical
-                className={`w-full px-4 lg:px-6 gap-y-6 ${
+                className={classNames(
+                  "w-full px-4 lg:px-6 gap-y-6",
                   !isUpdated ? "hidden" : ""
-                }`}
+                )}
               >
                 <Button
                   onClick={onClickContinueHandler}

--- a/frontend/app/(auth)/signup/page.tsx
+++ b/frontend/app/(auth)/signup/page.tsx
@@ -9,13 +9,11 @@ import { useRouter } from "next/navigation";
 import {
   Flex,
   Typography,
-  Spin,
   Input,
   Checkbox,
   Button,
   ConfigProvider,
 } from "antd";
-import { LoadingOutlined } from "@ant-design/icons";
 
 // import from components
 import Header from "@/components/auth/header/Header-0";

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,17 +1,15 @@
 "use client";
-import { useEffect, useState, useRef } from "react";
 
-const Counter = () => {
-  const effectRan = useRef(false);
-  useEffect(() => {
-    if (!effectRan.current) {
-      console.log("effect applied - only on the FIRST mount");
-    }
+import classNames from "classnames";
+import { useState } from "react";
 
-    return () => {
-      effectRan.current = true;
-    };
-  }, []);
-};
-
-export default Counter;
+export default function Page() {
+  const [flag] = useState(false);
+  return (
+    <div
+      className={classNames("font-bold", flag ? "text-[red]" : "text-[blue]")}
+    >
+      hello
+    </div>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "antd": "^5.17.4",
         "antd-input-otp": "^2.1.0",
         "autoprefixer": "^10.4.19",
+        "classnames": "^2.5.1",
         "countries-list": "^3.1.0",
         "iso-country-currency": "^0.7.2",
         "next": "14.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "antd": "^5.17.4",
     "antd-input-otp": "^2.1.0",
     "autoprefixer": "^10.4.19",
+    "classnames": "^2.5.1",
     "countries-list": "^3.1.0",
     "iso-country-currency": "^0.7.2",
     "next": "14.2.3",


### PR DESCRIPTION
Before this commits, ternary strings were used to set className of style.
By this commits, they are converted using classnames npm module.